### PR TITLE
Fix -0 values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export default function floydWarshall(adjMatrix) {
     } else {
       let val = adjMatrix.get(row, column);
 
-      if (val) {
+      if (val || Object.is(val, -0)) {
         // edges values remain the same
         distMatrix.set(row, column, val);
       } else {


### PR DESCRIPTION
-0 values are treated as 0 while they do not mean the same.  In my specific use case, my weight must be expressed as -ln(rate). If my rate is 1, my weight is -0.

 -0 === 0 and -0 == false so my -0 gets discarded as POSITIVE_INFINITY.